### PR TITLE
Deleting requirement for 'pry-byebug' that was causing an error when …

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ group :development, :test do
   gem 'rack_session_access'
   gem "capybara"
   gem "database_cleaner"
-  gem "pry-byebug"
   gem "rspec-rails"
 end
 


### PR DESCRIPTION
…running `rake db:migrate`

The following error occurs when any rake commands are run previous to deleting "gem 'pry-byebug'" from the gemfile.
$ rake  db:migrate
rake aborted!
NameError: uninitialized constant Pry::Command::ExitAll
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/pry-byebug-3.7.0/lib/pry-byebug/commands/exit_all.rb:7:in `<module:PryByebug>'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/pry-byebug-3.7.0/lib/pry-byebug/commands/exit_all.rb:3:in `<top (required)>'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/pry-byebug-3.7.0/lib/pry-byebug/commands.rb:12:in `require'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/pry-byebug-3.7.0/lib/pry-byebug/commands.rb:12:in `<top (required)>'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/pry-byebug-3.7.0/lib/pry-byebug/cli.rb:5:in `require'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/pry-byebug-3.7.0/lib/pry-byebug/cli.rb:5:in `<top (required)>'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/pry-0.13.1/lib/pry/plugins.rb:55:in `require'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/pry-0.13.1/lib/pry/plugins.rb:55:in `load_cli_options'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/pry-0.13.1/lib/pry/cli.rb:40:in `each'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/pry-0.13.1/lib/pry/cli.rb:40:in `add_plugin_options'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/pry-0.13.1/lib/pry/cli.rb:134:in `<top (required)>'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/pry-0.13.1/lib/pry.rb:78:in `require'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/pry-0.13.1/lib/pry.rb:78:in `<top (required)>'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/pry-byebug-3.7.0/lib/pry-byebug.rb:3:in `require'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/pry-byebug-3.7.0/lib/pry-byebug.rb:3:in `<top (required)>'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/bundler-2.1.4/lib/bundler/runtime.rb:74:in `require'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/bundler-2.1.4/lib/bundler/runtime.rb:74:in `block (2 levels) in require'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/bundler-2.1.4/lib/bundler/runtime.rb:69:in `each'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/bundler-2.1.4/lib/bundler/runtime.rb:69:in `block in require'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/bundler-2.1.4/lib/bundler/runtime.rb:58:in `each'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/bundler-2.1.4/lib/bundler/runtime.rb:58:in `require'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/bundler-2.1.4/lib/bundler.rb:174:in `require'
/Users/Brazenbillygoat/Desktop/Coding/flatiron/code/phase-two-rails-html/module-lab-sections/associations-and-rails/flatiron-taxi-join-the-fun/config/application.rb:7:in `<top (required)>'
/Users/Brazenbillygoat/Desktop/Coding/flatiron/code/phase-two-rails-html/module-lab-sections/associations-and-rails/flatiron-taxi-join-the-fun/Rakefile:4:in `require'
/Users/Brazenbillygoat/Desktop/Coding/flatiron/code/phase-two-rails-html/module-lab-sections/associations-and-rails/flatiron-taxi-join-the-fun/Rakefile:4:in `<top (required)>'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/gems/rake-13.0.1/exe/rake:27:in `<top (required)>'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/bin/ruby_executable_hooks:24:in `eval'
/Users/Brazenbillygoat/.rvm/gems/ruby-2.6.1/bin/ruby_executable_hooks:24:in `<main>'
(See full trace by running task with --trace)